### PR TITLE
Fix message delivery visibility and enhance chat UI

### DIFF
--- a/PeerShield/Services/MessageStore.swift
+++ b/PeerShield/Services/MessageStore.swift
@@ -21,6 +21,10 @@ final class MessageStore: ObservableObject {
         var arr = messages[m.contactID] ?? []
         arr.append(m)
         messages[m.contactID] = arr.sorted(by: { $0.timestamp < $1.timestamp })
+
+        // Manually notify listeners because mutating a dictionary key
+        // does not trigger the `@Published` publisher.
+        objectWillChange.send()
         persist()
     }
 

--- a/PeerShield/UI/ChatDetailView.swift
+++ b/PeerShield/UI/ChatDetailView.swift
@@ -27,20 +27,27 @@ struct ChatDetailView: View {
                         }
                     }.padding()
                 }
+                // Automatically keep the latest message in view
                 .onChange(of: messageStore.forContact(contact.id).count) { _ in
-                    // naive autoscroll
+                    if let last = messageStore.forContact(contact.id).last?.id {
+                        withAnimation { proxy.scrollTo(last, anchor: .bottom) }
+                    }
                 }
             }
 
             HStack {
                 TextField("Type a secure message", text: $draft)
                     .textFieldStyle(.roundedBorder)
-                Button("Send") {
+                Button(action: {
                     let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
                     guard !trimmed.isEmpty else { return }
                     peerService.send(message: trimmed, to: contact)
                     draft = ""
+                }) {
+                    Image(systemName: "paperplane.fill")
+                        .padding(.horizontal, 4)
                 }
+                .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 .buttonStyle(.borderedProminent)
             }
             .padding()


### PR DESCRIPTION
## Summary
- notify MessageStore observers after mutations so new messages appear
- add auto-scrolling and polished send button in chat view

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme PeerShield test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76a309dac8326b9f24ff34f8f1f59